### PR TITLE
Improve word splitting in wrapText function

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -37,6 +37,7 @@ local Size = require("ui/size")
 local Geom = require("ui/geometry")
 local _ = require("gettext")
 local BD = require("ui/bidi")
+local util = require("util")
 local DEFAULT_CONTENT_FONT_SIZE = 20
 local DEFAULT_TITLE_FONT_SIZE = 26
 local DEFAULT_INFO_FONT_SIZE = 17
@@ -352,24 +353,31 @@ end
 
 local function wrapText(text, face, max_width)
     local lines = {}
-    local words = {}
-    for word in text:gmatch("%S+") do table.insert(words, word) end
     local current_line = ""
+    local words = util.splitToWords(text)  
+    
     for _, word in ipairs(words) do
-        local test_line = current_line == "" and word or (current_line .. " " .. word)
+        local test_line = current_line == "" and word or (current_line .. word)
         local tw = TextWidget:new{ text = test_line, face = face }
         local w = tw:getSize().w
         tw:free()
+        
         if w <= max_width then
             current_line = test_line
         else
-            if current_line ~= "" then table.insert(lines, current_line) end
+            if current_line ~= "" then
+                table.insert(lines, current_line)
+            end
             current_line = word
         end
     end
-    if current_line ~= "" then table.insert(lines, current_line) end
+    
+    if current_line ~= "" then
+        table.insert(lines, current_line)
+    end
     return lines
 end
+
 local function createJustifiedLine(text, face, target_width, fgcolor)
     local words = {}
     for word in text:gmatch("%S+") do table.insert(words, word) end


### PR DESCRIPTION
## Problem
The Annotations Viewer plugin has a wrapText function that splits text into lines for display. The current implementation uses:
`for word in text:gmatch("%S+") do`

This pattern ` %S+` matches non-whitespace characters. For English text with spaces, this works fine. But for Chinese, Japanese, Korean (CJK) text, there are no spaces between characters, so the entire paragraph is treated as a single "word".As a result:
- The whole paragraph is rendered as one very long line
- Text extends beyond the screen width (no wrapping)
- The truncation feature (showing only N lines) doesn't work properly

## Solution
Fix CJK text wrapping in highlights: replace naive` %S+` pattern with ` util.splitToWords() ` to properly handle line breaks for Chinese/Japanese/Korean characters.

`util.splitToWords()`  (from KOReader's ` util.lua` ) does:
- Splits by spaces and punctuation first
- For any segment containing CJK characters, splits it into individual characters
- Returns a proper word/character array that can be measured and wrapped correctly